### PR TITLE
Update move_group.launch

### DIFF
--- a/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
+++ b/exercises/Perception-Driven_Manipulation/template_ws/src/ur5_collision_avoidance_moveit_config/launch/move_group.launch
@@ -14,7 +14,10 @@
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
-
+  
+  <param name="move_group/trajectory_execution/allowed_execution_duration_scaling" value="4.0"/>
+  <param name="move_group/trajectory_execution/execution_duration_monitoring" value="false"/>
+	
   <include ns="move_group" file="$(find ur5_collision_avoidance_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
   </include>


### PR DESCRIPTION
Added `allowed_execution_duration_scaling` and `execution_duration_monitoring` to bypass controller time out error. User may scale the value to increase the buffer for controller time out error.