### PR TITLE
Update Build-a-Moveit!-Package.md

### DIFF
--- a/gh_pages/_source/session3/Build-a-Moveit!-Package.md
+++ b/gh_pages/_source/session3/Build-a-Moveit!-Package.md
@@ -152,7 +152,7 @@ To do this, we need to define a few extra files.
       </include>
 
       <include file="$(find myworkcell_moveit_config)/launch/moveit_rviz.launch">
-        <!-- <arg name="config" value="true"/> -->
+        <arg name="config" value="true"/>
       </include>
 
     </launch>


### PR DESCRIPTION
Uncommented the line `<arg name="config" value="true"/>` to match the solution. Will return the existing RVIZ configuration instead of an empty RVIZ.